### PR TITLE
Refatora UI com estilo cômico leve e migra requisições para Dio

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'dart:convert';
+
 void main() {
   runApp(const MyApp());
 }
@@ -14,73 +14,160 @@ class MyApp extends StatelessWidget {
       title: 'NaaS API Calling App',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        colorScheme: .fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFFF7A59)),
+        textTheme: const TextTheme(
+          headlineMedium: TextStyle(
+            fontWeight: FontWeight.w800,
+            height: 1.25,
+          ),
+          bodyLarge: TextStyle(height: 1.4),
+        ),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
+  const MyHomePage({super.key});
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  String msg = "Aperte o botão para uma desculpa aleatória";
-  
-  Future<void> naasCall() async {
-    final url = Uri.parse('https://no-as-a-service-portuguese-ts.vercel.app/no');
-    
-    final res = await http.get(url);
-  
+  static const _defaultMessage = 'Aperte o botão para uma desculpa aleatória';
+
+  late final Dio _dio;
+  String _message = _defaultMessage;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://no-as-a-service-portuguese-ts.vercel.app',
+        connectTimeout: const Duration(seconds: 8),
+        receiveTimeout: const Duration(seconds: 8),
+      ),
+    );
+  }
+
+  Future<void> _fetchExcuse() async {
+    if (_isLoading) return;
+
+    setState(() => _isLoading = true);
+
     try {
-      if (res.statusCode == 200) {
-        setState(() {
-          msg = jsonDecode(res.body)["reason"];
-        });
-      } else {
-        setState(() {
-          msg = "Erro HTTP: ${res.statusCode}";
-        });
-      }
-    } catch (error) {
+      final response = await _dio.get<Map<String, dynamic>>('/no');
+      final reason = response.data?['reason'];
+
       setState(() {
-        msg = "Erro inesperado: $error";
+        _message = reason is String && reason.trim().isNotEmpty
+            ? reason
+            : 'A API respondeu sem desculpa válida.';
       });
+    } on DioException catch (error) {
+      setState(() {
+        if (error.response?.statusCode != null) {
+          _message = 'Erro HTTP: ${error.response?.statusCode}';
+        } else {
+          _message = 'Falha de conexão. Tente novamente.';
+        }
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
-  
+
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return Scaffold(
+      backgroundColor: const Color(0xFFFFF9F0),
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text("App de Chamada ao NaaS"),
+        elevation: 0,
+        centerTitle: true,
+        backgroundColor: colors.primaryContainer,
+        title: const Text('Gerador de Desculpas NaaS'),
       ),
-      body: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 20), 
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              msg,
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headlineMedium,
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 24,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(28),
+                      border: Border.all(color: const Color(0xFF1E1E1E), width: 2),
+                      boxShadow: const [
+                        BoxShadow(
+                          color: Color(0x22000000),
+                          blurRadius: 10,
+                          offset: Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        const Text('💬', style: TextStyle(fontSize: 44)),
+                        const SizedBox(height: 12),
+                        Text(
+                          _message,
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.headlineMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 28),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed: _isLoading ? null : _fetchExcuse,
+                      icon: _isLoading
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.casino_rounded),
+                      label: Text(_isLoading ? 'Consultando...' : 'Gerar desculpa'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        textStyle: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(18),
+                        ),
+                        backgroundColor: const Color(0xFFFFC145),
+                        foregroundColor: const Color(0xFF2E1E00),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
-            SizedBox(height: 30),
-            ElevatedButton(
-              onPressed: () => naasCall(), 
-              child: Text("Gerar desculpa")
-            )
-          ],
+          ),
         ),
-      ) 
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  http: ^1.2.0
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Tornar a interface mais atraente e legível com um visual cômico/caricato sutil sem aumentar a complexidade do app.
- Substituir a implementação de rede baseada em `http` por `dio` para oferecer timeouts, `baseUrl` e tratamento de erros mais robusto.
- Simplificar e otimizar o fluxo de atualização de estado para evitar cliques repetidos e melhorar feedback ao usuário.

### Description
- Substituído o uso de `http` por `dio` e atualizado `pubspec.yaml` para adicionar `dio: ^5.8.0+1` e remover `http`; a lógica de requisição foi movida para `Dio` com `BaseOptions` (inclui `baseUrl`, `connectTimeout` e `receiveTimeout`).
- Implementado tratamento de erros com `DioException` e mensagens de fallback para respostas inválidas e falhas de conexão na função `_fetchExcuse` em `lib/main.dart`.
- Refeito o layout da tela principal em `lib/main.dart` para um estilo cômico leve: uso de Material3, `ColorScheme` por seed, cartão com borda destacada e sombra, emoji de balão, tipografia mais forte e botão com indicador de carregamento e bloqueio de múltiplos cliques.
- Removido parâmetro de widget não utilizado e aplicada uma `ConstrainedBox` para manter responsividade em larguras maiores, mantendo a arquitetura simples e direta.

### Testing
- Tentativa de executar `flutter pub get` falhou no ambiente de CI/local por `flutter: command not found` e portanto dependências não foram instaladas automaticamente.
- Nenhuma suíte de testes automatizados foi executada neste ambiente após as alterações devido à indisponibilidade do Flutter SDK. 
- O código modificado foi verificado localmente para sintaxe e consistência de mudanças em `lib/main.dart` e `pubspec.yaml` antes de abrir o PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3d0a5a34832fa44accf35a670c39)